### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/amaneku/prettier-config.git"
+    "url": "git+https://github.com/amaneku/prettier-config.git"
   },
   "scripts": {
     "fmt": "prettier --write index.js",


### PR DESCRIPTION
## Summary
- update the package repository URL from SSH to public git+https
- keep runtime code, dependencies, package version, entry point, homepage, bugs metadata, and package contents unchanged

## Validation
- npm view @amaneku/prettier-config --json
- checked for duplicate upstream PRs/issues and Charles issues before submission
- node metadata assertion
- git diff --check
- npm ci --ignore-scripts --no-audit --no-fund
- npx prettier --check index.js
- npm pack --dry-run --ignore-scripts --json .